### PR TITLE
Add auth token to config

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,17 @@ end
 
 Both `action` and `batch_action` are optional. But at lease one of them is required
 
+# X-CG-AUTH-Token
+
+If your application needs to send the `X-CG-AUTH-Token` in the header of the requests, you should configure this in your application:
+
+`config/initializers/service_butler.rb`
+```ruby
+ServiceButler.configure do |config|
+  config.x_cg_auth_token = ENV["X_CG_AUTH_TOKEN"]
+end
+```
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/lib/service_butler/configuration.rb
+++ b/lib/service_butler/configuration.rb
@@ -3,6 +3,9 @@ module ServiceButler
     # Controls wether to fail silently when the host is unavailable.
     attr_writer :fail_connection_silently
 
+    # X-CG-AUTH-Token which will be added to the request header
+    attr_accessor :x_cg_auth_token
+
     def initialize
       @fail_connection_silently = true
     end

--- a/lib/service_butler/utilities/graphql_adapter.rb
+++ b/lib/service_butler/utilities/graphql_adapter.rb
@@ -5,7 +5,10 @@ module ServiceButler
     class GraphQLAdapter < ::GraphQL::Client::HTTP
       def headers(context)
         headers = {}
-        headers.merge!({'X-CG-AUTH-Token' => ENV['CG_MASTER_KEY']}) if ENV['CG_MASTER_KEY']
+
+        x_cg_auth_token = ServiceButler.configuration.x_cg_auth_token
+        headers.merge!({ 'X-CG-AUTH-Token' => x_cg_auth_token }) if x_cg_auth_token
+
         headers.merge!(context['headers']) if context['headers']
         headers
       end

--- a/lib/service_butler/version.rb
+++ b/lib/service_butler/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ServiceButler
-  VERSION = '0.3.7'
+  VERSION = '1.0.0'
 end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -13,4 +13,19 @@ RSpec.describe ServiceButler::Configuration do
       end
     end
   end
+
+  describe '#x_cg_auth_token' do
+    context 'when x_cg_auth_token has not been configured' do
+      it 'defaults to nil' do
+        expect(ServiceButler.configuration.x_cg_auth_token).to be_nil
+      end
+    end
+
+    context 'when x_cg_auth_token is configured' do
+      it 'returns the configured value' do
+        ServiceButler.configure { |config| config.x_cg_auth_token = 'my-auth-token' }
+        expect(ServiceButler.configuration.x_cg_auth_token).to eq 'my-auth-token'
+      end
+    end
+  end
 end

--- a/spec/service_butler/base_service_spec.rb
+++ b/spec/service_butler/base_service_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe ServiceButler::BaseService do
 
   describe 'Auth' do
     before do
-      ENV['CG_MASTER_KEY'] = 'EXAMPLEKEY'
+      ServiceButler.configure { |config| config.x_cg_auth_token = 'my-auth-token' }
     end
 
     it 'should set the CG auth token header' do
@@ -62,11 +62,7 @@ RSpec.describe ServiceButler::BaseService do
         batch_action 'versions'
       end
 
-      expect(ExampleGraphqlService.adapter.headers({})).to eq({'X-CG-AUTH-Token' => ENV['CG_MASTER_KEY']})
-    end
-
-    after do
-      ENV['CG_MASTER_KEY'] = nil
+      expect(ExampleGraphqlService.adapter.headers({})).to eq({'X-CG-AUTH-Token' => 'my-auth-token'})
     end
   end
 


### PR DESCRIPTION
Make the X-CG-AUTH-Token header for requests configurable in your application in stead of having this magically done by adding the env variable `X_CG_AUTH_TOKEN`

I've bumped it as  a major version because things will break if you don't add the configuration to your application. You guys agree with that?