### PR TITLE
Exception on 401

### DIFF
--- a/lib/service_butler/utilities/graphql_adapter.rb
+++ b/lib/service_butler/utilities/graphql_adapter.rb
@@ -9,6 +9,34 @@ module ServiceButler
         headers.merge!(context['headers']) if context['headers']
         headers
       end
+
+      def execute(document:, operation_name: nil, variables: {}, context: {})
+        request = Net::HTTP::Post.new(uri.request_uri)
+
+        request.basic_auth(uri.user, uri.password) if uri.user || uri.password
+
+        request["Accept"] = "application/json"
+        request["Content-Type"] = "application/json"
+        headers(context).each { |name, value| request[name] = value }
+
+        body = {}
+        body["query"] = document.to_query_string
+        body["variables"] = variables if variables.any?
+        body["operationName"] = operation_name if operation_name
+        request.body = JSON.generate(body)
+
+        response = connection.request(request)
+
+        raise StandardError.new "Connection to #{uri} failed. Response class: #{response.class}; Response code: #{response.code}" if response.code == '401'
+
+        case response
+        when Net::HTTPOK, Net::HTTPBadRequest
+          JSON.parse(response.body)
+        else
+          { "errors" => [{ "message" => "#{response.code} #{response.message}" }] }
+        end
+      end
+
     end
   end
 end

--- a/lib/service_butler/version.rb
+++ b/lib/service_butler/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ServiceButler
-  VERSION = '0.3.8'
+  VERSION = '0.3.9'
 end


### PR DESCRIPTION
overwrite the parent execute method. This does everything the same, except it checks if the response is a 401 and if so throw an error. in the graphql adapter line #30 is the only thing different compared to the parent implementation.